### PR TITLE
Fix html lang attribute

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -23,7 +23,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="ja">
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >


### PR DESCRIPTION
## Summary
- change root layout html language to Japanese

## Testing
- `npm run lint` *(fails: next not found)*
- `npm ci` *(fails: Exit handler never called)*
- `npm install` *(fails: Exit handler never called)*