### PR TITLE
Add heading test using React Testing Library

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+    '\\.(css|less|scss|sass)$': 'identity-obj-proxy'
+  }
+};

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,8 @@
+import '@testing-library/jest-dom';
+
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: (props: any) => {
+    return <img {...props} />;
+  },
+}));

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start -p $PORT",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "next": "15.3.2",
@@ -22,6 +23,12 @@
     "typescript": "^5",
     "@types/node": "^20",
     "@types/react": "^19",
-    "@types/react-dom": "^19"
+    "@types/react-dom": "^19",
+    "@testing-library/react": "^15",
+    "@testing-library/jest-dom": "^6",
+    "jest": "^29",
+    "ts-jest": "^29",
+    "jest-environment-jsdom": "^29",
+    "identity-obj-proxy": "^3"
   }
 }

--- a/src/__tests__/page.test.tsx
+++ b/src/__tests__/page.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from '@testing-library/react';
+import ResumePage from '../app/page';
+
+describe('ResumePage', () => {
+  it('renders main heading', () => {
+    render(<ResumePage />);
+    const heading = screen.getByRole('heading', { level: 1, name: /履歴書 \/ Curriculum Vitae/i });
+    expect(heading).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- setup Jest with React Testing Library
- add a simple test checking the Resume page heading

## Testing
- `npm test` *(fails: jest: not found)*